### PR TITLE
Clarify length of data payload description

### DIFF
--- a/definition.rst
+++ b/definition.rst
@@ -179,8 +179,10 @@ Description of record fields
 .. _field-12:
 
 :12: UINT32: **Length of data payload**.  Length, in bytes, of data
-     payload starting in field 15.  If no data payload, set this value
-     to 0.
+     payload starting in field 15.  If no data payload is present, 
+     set this value to 0. Note that no padding is permitted in the 
+     data record itself, although padding may exist within the 
+     payload depending on the type of encoding used.
 
 .. _field-13:
 


### PR DESCRIPTION
Per comments in iris-edu/miniSEED3#9, clarify in the description of the _Length of data payload_ field description that padding is not permitted at the record level, but padding may occur with some payload encodings